### PR TITLE
Supabase-only production deploy (frontend): auth gate, strict RLS, ENV-first, Vercel config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # eventverteiler-scout
-Exported from Scout jam: Create Event Distribution App with API &amp; UI Bots
+Exported from Scout jam: Create Event Distribution App with API & UI Bots
+
+## Struktur & Deployment-Hinweis
+- Deployed App: `event-distributor`
+- Nicht Teil des Deployments: `event-distributor-frontend-v2` (falls vorhanden – Template/Archiv)
+
+Details zur produktiven Supabase-Only-Bereitstellung (Vercel + strikte RLS) findest du unter:
+- `event-distributor/README.md` → Abschnitt „Deployment (Supabase-only, Production)“
+

--- a/event-distributor/index.html
+++ b/event-distributor/index.html
@@ -1,83 +1,6 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="de">
   <head>
-<script type="text/javascript">
-  // This is a CodeSandbox injection script that's used to
-  // add navigation and inspector functionality to the preview
-  (function () {
-    // 1) Get the <script> tag that's currently running:
-    var me = document.currentScript;
-
-    // 2) Create the blocking‐style <script> to load:
-    var script = document.createElement("script");
-    script.src = "https://codesandbox.io/p/preview-protocol.js";
-
-    // By default a dynamically‐inserted <script> is async=true.
-    // Turn async off to make it behave like a normal blocking <script>:
-    script.async = false;
-    // (Do NOT set defer.)
-
-    // 3) Insert it immediately after the current <script>:
-    me.parentNode.insertBefore(script, me);
-  })();
-
-  const isIFramePreview = window.top !== window.self;
-
-  // Only run this script in editor context
-  if (isIFramePreview) {
-    // This script is used to enable Chrome DevTools functionality
-    (function () {
-      var script = document.createElement("script");
-      script.src =
-        "https://codesandbox.io/p/chrome-devtool/protocol/index.js";
-
-      script.onload = () => {
-        const devtoolProtocol = window.chobitsu;
-        if (devtoolProtocol) {
-          window.addEventListener("message", (event) => {
-            const { type, data } = event.data;
-
-            if (type === "FROM_DEVTOOL") {
-              devtoolProtocol.sendRawMessage(data);
-            }
-          });
-
-          devtoolProtocol.setOnMessage((data) => {
-            if (data.includes('"id":"tmp')) {
-              return;
-            }
-
-            window.parent.postMessage({ type: "TO_DEVTOOL", data }, "*");
-          });
-
-          devtoolProtocol.sendRawMessage(
-            `{"id":5,"method":"Runtime.enable","params":{}}`
-          );
-        }        
-      }
-
-      (document.head || document.documentElement).prepend(script);
-    })();
-  }
-
-  if (typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ === "undefined") {
-    let nextID = 0;
-    let hook = (__REACT_DEVTOOLS_GLOBAL_HOOK__ = {
-      renderers: new Map(),
-      supportsFiber: true,
-      inject: (renderer) => {
-        const id = nextID++;
-        hook.renderers.set(id, renderer);
-        return id;
-      },
-      onScheduleFiberRoot() {},
-      onCommitFiberRoot() {},
-      onCommitFiberUnmount() {},
-    });
-  }
-
-  document.currentScript.remove();
-</script>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -86,7 +9,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <!-- cache-bust -->
-    <script type="module" src="/client/main.tsx?v=2025-09-01-02"></script>
+    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/event-distributor/src/App.tsx
+++ b/event-distributor/src/App.tsx
@@ -6,7 +6,7 @@ function set(k: string, v: string) { try { localStorage.setItem(k, v); } catch {
 export default function App() {
   const [tab, setTab] = useState<'dashboard'|'platforms'|'logs'>('platforms');
 
-  const [mode, setMode] = useState(get('appMode','api'));
+  const [mode, setMode] = useState(get('appMode','supabase'));
   const [apiBase, setApiBase] = useState(get('apiBase','http://localhost:8080'));
   const [supabaseUrl, setSupabaseUrl] = useState(get('supabaseUrl',''));
   const [supabaseAnon, setSupabaseAnon] = useState(get('supabaseAnon',''));
@@ -69,6 +69,7 @@ export default function App() {
                   <input className="w-full border rounded p-2 mt-1" value={supabaseAnon} onChange={(e)=>setSupabaseAnon(e.target.value)} placeholder="public anon key" />
                 </label>
               </div>
+              <p className="text-xs text-gray-500">Wenn in Vercel ENV gesetzt sind, werden sie automatisch genutzt; die Felder hier dienen als Fallback.</p>
               <div className="text-right"><button className="px-4 py-2 rounded bg-blue-600 text-white" onClick={persistConnectivity}>Übernehmen</button></div>
             </section>
 

--- a/event-distributor/src/auth/AuthGate.tsx
+++ b/event-distributor/src/auth/AuthGate.tsx
@@ -1,0 +1,47 @@
+import { PropsWithChildren, useEffect, useState } from 'react';
+import SignIn from './SignIn';
+import { supa } from '../services/supabase';
+
+export default function AuthGate({ children }: PropsWithChildren) {
+  const [ready, setReady] = useState(false);
+  const [isAuthed, setAuthed] = useState(false);
+
+  useEffect(() => {
+    let unsub: (() => void) | undefined;
+    (async () => {
+      try {
+        const sb = supa();
+        const { data } = await sb.auth.getSession();
+        setAuthed(!!data.session);
+        const { data: listener } = sb.auth.onAuthStateChange((_event, session) => {
+          setAuthed(!!session);
+        });
+        unsub = () => listener.subscription.unsubscribe();
+      } catch (e) {
+        // Missing configuration will be surfaced by SignIn
+      } finally {
+        setReady(true);
+      }
+    })();
+    return () => {
+      if (unsub) try { unsub(); } catch {}
+    };
+  }, []);
+
+  if (!ready) return <div className="min-h-screen grid place-items-center text-gray-500">Laden…</div>;
+  if (!isAuthed) return <SignIn />;
+
+  return (
+    <div>
+      <div className="fixed top-2 right-2 z-50">
+        <button
+          className="text-sm px-3 py-1 rounded bg-gray-900 text-white hover:opacity-90"
+          onClick={() => supa().auth.signOut()}
+        >
+          Abmelden
+        </button>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/event-distributor/src/auth/SignIn.tsx
+++ b/event-distributor/src/auth/SignIn.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+import { supa } from '../services/supabase';
+import { getSupabaseUrl, getSupabaseAnon } from '../services/config';
+
+export default function SignIn() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const haveEnv = !!getSupabaseUrl() && !!getSupabaseAnon();
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      const sb = supa();
+      const { error } = await sb.auth.signInWithPassword({ email, password });
+      if (error) throw error;
+    } catch (err: any) {
+      setError(err?.message || 'Anmeldung fehlgeschlagen');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen grid place-items-center bg-gray-50">
+      <div className="w-full max-w-sm p-6 bg-white shadow rounded">
+        <h1 className="text-xl font-semibold">Anmeldung</h1>
+        <p className="text-sm text-gray-600 mt-1">Bitte mit deinem Admin-Account anmelden.</p>
+
+        {!haveEnv && (
+          <div className="mt-4 text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded p-2">
+            Supabase URL/Anon Key sind nicht konfiguriert. Setze VITE_SUPABASE_URL und VITE_SUPABASE_ANON in deiner Umgebung
+            oder hinterlege sie lokal unter "Plattformen – Konnektivität" nach dem Login. In Vercel werden ENV-Variablen automatisch verwendet.
+          </div>
+        )}
+
+        <form onSubmit={onSubmit} className="mt-6 space-y-3">
+          <label className="block text-sm">
+            E-Mail
+            <input
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="mt-1 w-full border rounded p-2"
+              placeholder="admin@example.com"
+            />
+          </label>
+          <label className="block text-sm">
+            Passwort
+            <input
+              type="password"
+              required
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="mt-1 w-full border rounded p-2"
+              placeholder="••••••••"
+            />
+          </label>
+          {error && <div className="text-sm text-red-600">{error}</div>}
+          <button
+            type="submit"
+            className="w-full px-4 py-2 rounded bg-blue-600 text-white disabled:opacity-60"
+            disabled={loading}
+          >
+            {loading ? 'Anmelden…' : 'Anmelden'}
+          </button>
+          <p className="text-[11px] text-gray-500">Wenn in Vercel ENV gesetzt sind, werden sie automatisch genutzt; die Felder im App-Tab dienen als Fallback.</p>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/event-distributor/src/main.tsx
+++ b/event-distributor/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import AuthGate from './auth/AuthGate'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <AuthGate>
+      <App />
+    </AuthGate>
   </StrictMode>,
 )

--- a/event-distributor/src/services/config.ts
+++ b/event-distributor/src/services/config.ts
@@ -8,8 +8,8 @@ const keys = {
 };
 
 export function getMode(): AppMode {
-  if (typeof window === 'undefined') return 'api';
-  return (localStorage.getItem(keys.mode) as AppMode) || 'api';
+  if (typeof window === 'undefined') return 'supabase';
+  return (localStorage.getItem(keys.mode) as AppMode) || 'supabase';
 }
 export function setMode(m: AppMode) {
   if (typeof window !== 'undefined') localStorage.setItem(keys.mode, m);
@@ -28,6 +28,8 @@ export function setApiBase(url: string) {
 }
 
 export function getSupabaseUrl() {
+  const env = (import.meta as any)?.env?.VITE_SUPABASE_URL;
+  if (env) return env;
   if (typeof window !== 'undefined') return localStorage.getItem(keys.supabaseUrl) || '';
   return '';
 }
@@ -35,6 +37,8 @@ export function setSupabaseUrl(v: string) {
   if (typeof window !== 'undefined') localStorage.setItem(keys.supabaseUrl, v);
 }
 export function getSupabaseAnon() {
+  const env = (import.meta as any)?.env?.VITE_SUPABASE_ANON;
+  if (env) return env;
   if (typeof window !== 'undefined') return localStorage.getItem(keys.supabaseAnon) || '';
   return '';
 }

--- a/event-distributor/supabase/rls_prod.sql
+++ b/event-distributor/supabase/rls_prod.sql
@@ -1,0 +1,102 @@
+-- Production RLS policies for Event-Verteiler (Supabase-only)
+--
+-- IMPORTANT
+-- 1) This script enables RLS on all app tables and creates STRICT policies.
+-- 2) By default, ONLY authenticated users can read and write.
+-- 3) OPTIONAL: You can restrict access to a single admin account by email.
+--    To do so, replace <ADMIN_EMAIL> below and UNCOMMENT the single-admin section,
+--    then DROP the generic authenticated-only policies or run this in a clean project.
+--
+-- Tables covered:
+--   "Event", "EventVersion", "PlatformConfig", "PublishJob", "EventPublication", "LogEntry"
+--
+-- Remove any demo/open policies before applying this file.
+
+-- Enable RLS on all tables
+alter table "Event" enable row level security;
+alter table "EventVersion" enable row level security;
+alter table "PlatformConfig" enable row level security;
+alter table "PublishJob" enable row level security;
+alter table "EventPublication" enable row level security;
+alter table "LogEntry" enable row level security;
+
+-- ==============================================
+-- VARIANT A (DEFAULT): Authenticated-only access
+-- ==============================================
+-- Event
+drop policy if exists "event_select_authenticated" on "Event";
+drop policy if exists "event_modify_authenticated" on "Event";
+create policy "event_select_authenticated" on "Event" for select using (auth.role() = 'authenticated');
+create policy "event_modify_authenticated" on "Event" for all using (auth.role() = 'authenticated') with check (auth.role() = 'authenticated');
+
+-- EventVersion
+drop policy if exists "eventversion_select_authenticated" on "EventVersion";
+drop policy if exists "eventversion_modify_authenticated" on "EventVersion";
+create policy "eventversion_select_authenticated" on "EventVersion" for select using (auth.role() = 'authenticated');
+create policy "eventversion_modify_authenticated" on "EventVersion" for all using (auth.role() = 'authenticated') with check (auth.role() = 'authenticated');
+
+-- PlatformConfig
+drop policy if exists "platformconfig_select_authenticated" on "PlatformConfig";
+drop policy if exists "platformconfig_modify_authenticated" on "PlatformConfig";
+create policy "platformconfig_select_authenticated" on "PlatformConfig" for select using (auth.role() = 'authenticated');
+create policy "platformconfig_modify_authenticated" on "PlatformConfig" for all using (auth.role() = 'authenticated') with check (auth.role() = 'authenticated');
+
+-- PublishJob
+drop policy if exists "publishjob_select_authenticated" on "PublishJob";
+drop policy if exists "publishjob_modify_authenticated" on "PublishJob";
+create policy "publishjob_select_authenticated" on "PublishJob" for select using (auth.role() = 'authenticated');
+create policy "publishjob_modify_authenticated" on "PublishJob" for all using (auth.role() = 'authenticated') with check (auth.role() = 'authenticated');
+
+-- EventPublication
+drop policy if exists "eventpublication_select_authenticated" on "EventPublication";
+drop policy if exists "eventpublication_modify_authenticated" on "EventPublication";
+create policy "eventpublication_select_authenticated" on "EventPublication" for select using (auth.role() = 'authenticated');
+create policy "eventpublication_modify_authenticated" on "EventPublication" for all using (auth.role() = 'authenticated') with check (auth.role() = 'authenticated');
+
+-- LogEntry
+drop policy if exists "logentry_select_authenticated" on "LogEntry";
+drop policy if exists "logentry_modify_authenticated" on "LogEntry";
+create policy "logentry_select_authenticated" on "LogEntry" for select using (auth.role() = 'authenticated');
+create policy "logentry_modify_authenticated" on "LogEntry" for all using (auth.role() = 'authenticated') with check (auth.role() = 'authenticated');
+
+-- =====================================================================================
+-- VARIANT B (OPTIONAL): Single admin by email (uncomment and set <ADMIN_EMAIL> to enforce)
+-- =====================================================================================
+-- NOTE: If you enable this, remove or drop the policies from VARIANT A to avoid overlap.
+-- Replace <ADMIN_EMAIL> with your admin's email address.
+--
+-- -- Event
+-- drop policy if exists "event_select_admin" on "Event";
+-- drop policy if exists "event_modify_admin" on "Event";
+-- create policy "event_select_admin" on "Event" for select using ((auth.role() = 'authenticated') and (auth.jwt() ->> 'email' = '<ADMIN_EMAIL>'));
+-- create policy "event_modify_admin" on "Event" for all using ((auth.role() = 'authenticated') and (auth.jwt() ->> 'email' = '<ADMIN_EMAIL>')) with check ((auth.role() = 'authenticated') and (auth.jwt() ->> 'email' = '<ADMIN_EMAIL>'));
+--
+-- -- EventVersion
+-- drop policy if exists "eventversion_select_admin" on "EventVersion";
+-- drop policy if exists "eventversion_modify_admin" on "EventVersion";
+-- create policy "eventversion_select_admin" on "EventVersion" for select using ((auth.role() = 'authenticated') and (auth.jwt() ->> 'email' = '<ADMIN_EMAIL>'));
+-- create policy "eventversion_modify_admin" on "EventVersion" for all using ((auth.role() = 'authenticated') and (auth.jwt() ->> 'email' = '<ADMIN_EMAIL>')) with check ((auth.role() = 'authenticated') and (auth.jwt() ->> 'email' = '<ADMIN_EMAIL>'));
+--
+-- -- PlatformConfig
+-- drop policy if exists "platformconfig_select_admin" on "PlatformConfig";
+-- drop policy if exists "platformconfig_modify_admin" on "PlatformConfig";
+-- create policy "platformconfig_select_admin" on "PlatformConfig" for select using ((auth.role() = 'authenticated') and (auth.jwt() ->> 'email' = '<ADMIN_EMAIL>'));
+-- create policy "platformconfig_modify_admin" on "PlatformConfig" for all using ((auth.role() = 'authenticated') and (auth.jwt() ->> 'email' = '<ADMIN_EMAIL>')) with check ((auth.role() = 'authenticated') and (auth.jwt() ->> 'email' = '<ADMIN_EMAIL>'));
+--
+-- -- PublishJob
+-- drop policy if exists "publishjob_select_admin" on "PublishJob";
+-- drop policy if exists "publishjob_modify_admin" on "PublishJob";
+-- create policy "publishjob_select_admin" on "PublishJob" for select using ((auth.role() = 'authenticated') and (auth.jwt() ->> 'email' = '<ADMIN_EMAIL>'));
+-- create policy "publishjob_modify_admin" on "PublishJob" for all using ((auth.role() = 'authenticated') and (auth.jwt() ->> 'email' = '<ADMIN_EMAIL>')) with check ((auth.role() = 'authenticated') and (auth.jwt() ->> 'email' = '<ADMIN_EMAIL>'));
+--
+-- -- EventPublication
+-- drop policy if exists "eventpublication_select_admin" on "EventPublication";
+-- drop policy if exists "eventpublication_modify_admin" on "EventPublication";
+-- create policy "eventpublication_select_admin" on "EventPublication" for select using ((auth.role() = 'authenticated') and (auth.jwt() ->> 'email' = '<ADMIN_EMAIL>'));
+-- create policy "eventpublication_modify_admin" on "EventPublication" for all using ((auth.role() = 'authenticated') and (auth.jwt() ->> 'email' = '<ADMIN_EMAIL>')) with check ((auth.role() = 'authenticated') and (auth.jwt() ->> 'email' = '<ADMIN_EMAIL>'));
+--
+-- -- LogEntry
+-- drop policy if exists "logentry_select_admin" on "LogEntry";
+-- drop policy if exists "logentry_modify_admin" on "LogEntry";
+-- create policy "logentry_select_admin" on "LogEntry" for select using ((auth.role() = 'authenticated') and (auth.jwt() ->> 'email' = '<ADMIN_EMAIL>'));
+-- create policy "logentry_modify_admin" on "LogEntry" for all using ((auth.role() = 'authenticated') and (auth.jwt() ->> 'email' = '<ADMIN_EMAIL>')) with check ((auth.role() = 'authenticated') and (auth.jwt() ->> 'email' = '<ADMIN_EMAIL>'));

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "installCommand": "cd event-distributor && bun install",
+  "buildCommand": "cd event-distributor && bun run build",
+  "outputDirectory": "event-distributor/dist",
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
This PR implements a production-grade, Supabase-only deployment for the event-distributor frontend.

Highlights
- Default runtime: supabase; localStorage override still supported.
- ENV-first config: VITE_SUPABASE_URL / VITE_SUPABASE_ANON preferred (Vercel). Fallback to localStorage.
- Auth gating: minimal Supabase email+password Sign-In; session persistence; Sign-Out; app content hidden until authenticated.
- Strict RLS: new SQL at event-distributor/supabase/rls_prod.sql enabling RLS across all tables with authenticated-only policies; optional single-admin-by-email variant documented inside file.
- UI notes: small hint near Supabase inputs clarifying ENV usage as automatic.
- Docs: deployment steps added to event-distributor/README.md; root README clarifies structure and links to deployment section.
- Vercel (root) vercel.json: monorepo build + SPA rewrite.

Non-goals
- No backend/Express changes. event-distributor-frontend-v2 remains unused (documented as template/archive).

Post-merge actions
1) Set Vercel ENV for Production/Preview/Development:
   - VITE_SUPABASE_URL = https://owkkygszfljtkhjidmnv.supabase.co
   - VITE_SUPABASE_ANON = <anon key>
2) Apply event-distributor/supabase/rls_prod.sql in Supabase SQL Editor (choose generic authenticated-only or single-admin variant).
3) Create admin user in Supabase Auth and verify the app gates unauthenticated access and enables CRUD after login.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Scout](https://scout.new) ([view task](https://scout.new/project/24cf7f97-98af-44eb-906e-389df10ea0d4/task/d4630fbf-f03a-42a4-b077-7193e244591d))