### PR TITLE
Fix: detect Supabase env from Vercel/Supabase native variables

### DIFF
--- a/event-distributor/src/services/config.ts
+++ b/event-distributor/src/services/config.ts
@@ -28,8 +28,9 @@ export function setApiBase(url: string) {
 }
 
 export function getSupabaseUrl() {
-  const env = (import.meta as any)?.env?.VITE_SUPABASE_URL;
-  if (env) return env;
+  const envs: any = (import.meta as any)?.env || {};
+  const env = envs.VITE_SUPABASE_URL || envs.NEXT_PUBLIC_SUPABASE_URL || envs.SUPABASE_URL || envs.PUBLIC_SUPABASE_URL;
+  if (env) return env as string;
   if (typeof window !== 'undefined') return localStorage.getItem(keys.supabaseUrl) || '';
   return '';
 }
@@ -37,8 +38,9 @@ export function setSupabaseUrl(v: string) {
   if (typeof window !== 'undefined') localStorage.setItem(keys.supabaseUrl, v);
 }
 export function getSupabaseAnon() {
-  const env = (import.meta as any)?.env?.VITE_SUPABASE_ANON;
-  if (env) return env;
+  const envs: any = (import.meta as any)?.env || {};
+  const env = envs.VITE_SUPABASE_ANON || envs.VITE_SUPABASE_ANON_KEY || envs.NEXT_PUBLIC_SUPABASE_ANON_KEY || envs.SUPABASE_ANON_KEY || envs.PUBLIC_SUPABASE_ANON_KEY;
+  if (env) return env as string;
   if (typeof window !== 'undefined') return localStorage.getItem(keys.supabaseAnon) || '';
   return '';
 }


### PR DESCRIPTION
Fixes missing Supabase config when using Vercel ↔ Supabase native integration.

Change
- In getSupabaseUrl/getSupabaseAnon, accept additional env names used by the native integration: SUPABASE_URL, SUPABASE_ANON_KEY, NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY, PUBLIC_* variants. Still prefers VITE_* when present.

Impact
- Eliminates false 'Supabase URL/Anon Key sind nicht konfiguriert' warning on Vercel when only native integration is used and VITE_* vars are not set.

No UI changes beyond the warning disappearing when env present. Build verified.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Scout](https://scout.new) ([view task](https://scout.new/project/24cf7f97-98af-44eb-906e-389df10ea0d4/task/d4630fbf-f03a-42a4-b077-7193e244591d))