### PR TITLE
Build: Vite env bridge for Supabase on Vercel (no VITE_* required)

### DIFF
--- a/event-distributor/vite.config.ts
+++ b/event-distributor/vite.config.ts
@@ -8,10 +8,7 @@ function injectBuiltByScoutPlugin() {
   return {
     name: 'inject-built-by-scout',
     transformIndexHtml(html: string) {
-      // Inject the scout tag script reference
       const scriptTag = '<script defer src="/scout-tag.js"></script>';
-      
-      // Inject the script before the closing body tag
       return html.replace('</body>', scriptTag + '\n  </body>');
     }
   };
@@ -24,5 +21,22 @@ export default defineConfig({
     alias: {
       "@": path.resolve(__dirname, "./src"),
     },
+  },
+  // Bridge native Vercel↔Supabase env names into Vite's client-exposed VITE_* vars
+  define: {
+    'import.meta.env.VITE_SUPABASE_URL': JSON.stringify(
+      process.env.VITE_SUPABASE_URL ||
+      process.env.NEXT_PUBLIC_SUPABASE_URL ||
+      process.env.SUPABASE_URL ||
+      process.env.PUBLIC_SUPABASE_URL ||
+      ''
+    ),
+    'import.meta.env.VITE_SUPABASE_ANON': JSON.stringify(
+      process.env.VITE_SUPABASE_ANON ||
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+      process.env.SUPABASE_ANON_KEY ||
+      process.env.PUBLIC_SUPABASE_ANON_KEY ||
+      ''
+    ),
   },
 });


### PR DESCRIPTION
This ensures the Vercel↔Supabase native integration works without duplicating env to VITE_*.

Change
- Add define{} in Vite config to map SUPABASE_URL / SUPABASE_ANON_KEY (and NEXT_PUBLIC_* variants) into VITE_SUPABASE_URL / VITE_SUPABASE_ANON at build-time.

Why
- Vite only exposes env prefixed with VITE_* to the client. Native integration sets SUPABASE_* / NEXT_PUBLIC_*.

Result
- The frontend receives the correct values, removing the 'Supabase URL/Anon Key nicht konfiguriert' warning on Vercel deployments using the native integration.

No runtime code changes beyond this mapping. Local dev still works with .env files.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Scout](https://scout.new) ([view task](https://scout.new/project/24cf7f97-98af-44eb-906e-389df10ea0d4/task/d4630fbf-f03a-42a4-b077-7193e244591d))