### PR TITLE
Auth UX: persistent local Supabase config until explicit save

### DIFF
--- a/event-distributor/src/auth/SignIn.tsx
+++ b/event-distributor/src/auth/SignIn.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { supa } from '../services/supabase';
+import { useMemo, useState } from 'react';
+import { supa, resetSupa } from '../services/supabase';
 import { getSupabaseUrl, getSupabaseAnon, setSupabaseUrl, setSupabaseAnon } from '../services/config';
 
 export default function SignIn() {
@@ -8,9 +8,12 @@ export default function SignIn() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const [sbUrl, setSbUrl] = useState(getSupabaseUrl());
-  const [sbAnon, setSbAnon] = useState(getSupabaseAnon());
-  const haveEnv = !!sbUrl && !!sbAnon;
+  const envPresent = useMemo(() => {
+    try { return !!getSupabaseUrl() && !!getSupabaseAnon(); } catch { return false; }
+  }, []);
+  const [showConfig, setShowConfig] = useState(!envPresent);
+  const [sbUrl, setSbUrl] = useState(getSupabaseUrl() || '');
+  const [sbAnon, setSbAnon] = useState(getSupabaseAnon() || '');
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -31,6 +34,7 @@ export default function SignIn() {
     try {
       setSupabaseUrl(sbUrl);
       setSupabaseAnon(sbAnon);
+      resetSupa();
       window.location.reload();
     } catch {}
   }
@@ -41,7 +45,7 @@ export default function SignIn() {
         <h1 className="text-xl font-semibold">Anmeldung</h1>
         <p className="text-sm text-gray-600 mt-1">Bitte mit deinem Admin-Account anmelden.</p>
 
-        {!haveEnv && (
+        {showConfig && (
           <div className="mt-4 space-y-2 text-xs">
             <div className="text-amber-700 bg-amber-50 border border-amber-200 rounded p-2">
               Supabase URL/Anon Key sind nicht konfiguriert. In Vercel werden ENV-Variablen automatisch verwendet. Alternativ hier lokal hinterlegen:


### PR DESCRIPTION
Fixes disappearing 'Übernehmen' controls during config entry on Sign-In.

Change
- Sign-In shows Supabase URL/Anon inputs when env missing and keeps them visible until user clicks 'Übernehmen'. This persists to localStorage, resets client, and reloads, ensuring the login can proceed.

Why
- Previously the inputs vanished as soon as both fields were non-empty, preventing reliable save.

Result
- Bulletproof fallback config path; combined with robust supabase resolution (#6), login proceeds once values are saved.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Scout](https://scout.new) ([view task](https://scout.new/project/24cf7f97-98af-44eb-906e-389df10ea0d4/task/d4630fbf-f03a-42a4-b077-7193e244591d))