### PR TITLE
Spontacts publish (Supabase-only): fields, mapping, job scheduling, platform configs

### DIFF
--- a/event-distributor/bots/src/spontacts/createEvent.ts
+++ b/event-distributor/bots/src/spontacts/createEvent.ts
@@ -2,6 +2,7 @@ import { chromium } from '@playwright/test';
 import { loadOrCreateSession } from '../shared/session.js';
 import { smartFill, clickByText } from '../shared/helpers.js';
 import { createArtifacts } from '../shared/logging.js';
+import { mapToSpontactsFields } from '../../../shared/platforms/spontacts';
 
 const event = JSON.parse(process.env.EVENT_JSON || '{}');
 const jobId = process.env.JOB_ID || 'local';
@@ -18,46 +19,40 @@ const cfg = JSON.parse(process.env.BOT_CONFIG || '{}');
     await page.waitForLoadState('domcontentloaded');
 
     if (cfg.email && cfg.password) {
-      // Try to open login
       await clickByText(page, 'Login').catch(() => {});
       await page.waitForLoadState('networkidle').catch(() => {});
-      await smartFill(page, 'E-Mail', cfg.email);
-      await smartFill(page, 'Email', cfg.email);
-      await smartFill(page, 'Passwort', cfg.password);
-      await smartFill(page, 'Password', cfg.password);
+      await smartFill(page, 'E-Mail', cfg.email) || await smartFill(page, 'Email', cfg.email);
+      await smartFill(page, 'Passwort', cfg.password) || await smartFill(page, 'Password', cfg.password);
       await clickByText(page, 'Anmelden').catch(() => clickByText(page, 'Login'));
       await page.waitForLoadState('networkidle');
       await session.save();
     }
 
-    // Navigate to create activity/event page
     const createBtn = (await clickByText(page, 'Aktivität erstellen')) || (await clickByText(page, 'Create activity'));
     if (!createBtn) {
       await page.goto('https://www.spontacts.com/activities/new').catch(() => {});
     }
 
     await page.waitForLoadState('domcontentloaded');
-    if (event.title) {
-      await smartFill(page, 'Titel', event.title) || await smartFill(page, 'Title', event.title);
-    }
-    if (event.description) {
-      await smartFill(page, 'Beschreibung', event.description) || await smartFill(page, 'Description', event.description);
-    }
-    if (event.date) {
-      await smartFill(page, 'Datum', new Date(event.date).toLocaleDateString()) || await smartFill(page, 'Date', new Date(event.date).toLocaleDateString());
-    }
-    if (event.time) {
-      await smartFill(page, 'Uhrzeit', event.time) || await smartFill(page, 'Time', event.time);
-    }
+
+    const m = mapToSpontactsFields(event);
+    if (m.title) await smartFill(page, 'Titel', m.title) || await smartFill(page, 'Title', m.title);
+    if (m.description) await smartFill(page, 'Beschreibung', m.description) || await smartFill(page, 'Description', m.description);
+    if (m.date) await smartFill(page, 'Datum', new Date(m.date).toLocaleDateString()) || await smartFill(page, 'Date', new Date(m.date).toLocaleDateString());
+    if (m.time) await smartFill(page, 'Uhrzeit', m.time) || await smartFill(page, 'Time', m.time);
+    if (m.category) await smartFill(page, 'Kategorie', m.category) || await smartFill(page, 'Category', m.category);
+    if (m.city) await smartFill(page, 'Ort', m.city) || await smartFill(page, 'City', m.city);
+    if (m.meetingPoint) await smartFill(page, 'Treffpunkt', m.meetingPoint) || await smartFill(page, 'Meeting point', m.meetingPoint);
+    if (m.maxParticipants) await smartFill(page, 'Teilnehmer', String(m.maxParticipants)) || await smartFill(page, 'Participants', String(m.maxParticipants));
+    if (m.price) await smartFill(page, 'Preis', String(m.price)) || await smartFill(page, 'Price', String(m.price));
 
     await clickByText(page, 'Veröffentlichen') || await clickByText(page, 'Publish');
     await page.waitForLoadState('networkidle');
     await art.save(page, 'after-publish');
 
-    // Verify in "Meine Aktivitäten"
     await page.goto('https://www.spontacts.com/my-activities').catch(() => page.goto('https://www.spontacts.com/activities/mine'));
     await page.waitForLoadState('domcontentloaded');
-    const visible = await page.getByText(event.title, { exact: false }).first().isVisible().catch(() => false);
+    const visible = await page.getByText(m.title, { exact: false }).first().isVisible().catch(() => false);
     if (!visible) throw new Error('Verification failed: event title not visible on Spontacts my activities');
 
     await session.save();

--- a/event-distributor/shared/platforms/spontacts.ts
+++ b/event-distributor/shared/platforms/spontacts.ts
@@ -1,0 +1,29 @@
+import type { EventInput } from '../../shared/types';
+
+export type SpontactsExtra = {
+  category?: string;
+  city?: string;
+  meetingPoint?: string;
+  maxParticipants?: number;
+  visibility?: 'public' | 'friends' | 'private';
+  difficulty?: string;
+};
+
+export function mapToSpontactsFields(e: any) {
+  const extras: SpontactsExtra = e?.spontacts || {};
+  return {
+    title: e.title || '',
+    description: e.description || '',
+    date: e.date || '',
+    time: e.time || '',
+    category: extras.category || e.category || '',
+    city: extras.city || (typeof e.location === 'string' ? e.location : e.location?.city || ''),
+    meetingPoint: extras.meetingPoint || '',
+    maxParticipants: extras.maxParticipants || undefined,
+    visibility: extras.visibility || 'public',
+    difficulty: extras.difficulty || '',
+    price: e.price || 0,
+    images: e.images || [],
+    isVirtual: !!e.isVirtual,
+  };
+}

--- a/event-distributor/shared/types.ts
+++ b/event-distributor/shared/types.ts
@@ -11,6 +11,14 @@ export type EventInput = {
   images?: string[];
   organizer?: string;
   url?: string;
+  spontacts?: {
+    category?: string;
+    city?: string;
+    meetingPoint?: string;
+    maxParticipants?: number;
+    visibility?: 'public' | 'friends' | 'private';
+    difficulty?: string;
+  };
 };
 
 export type PlatformKey = 'meetup' | 'eventbrite' | 'facebook' | 'spontacts';

--- a/event-distributor/src/App.tsx
+++ b/event-distributor/src/App.tsx
@@ -1,38 +1,9 @@
 import { useState } from 'react';
-
-function get(k: string, d = '') { try { return localStorage.getItem(k) ?? d; } catch { return d; } }
-function set(k: string, v: string) { try { localStorage.setItem(k, v); } catch {} }
+import Dashboard from './pages/Dashboard';
+import { PlatformsInline } from './components/PlatformsInline';
 
 export default function App() {
-  const [tab, setTab] = useState<'dashboard'|'platforms'|'logs'>('platforms');
-
-  const [mode, setMode] = useState(get('appMode','supabase'));
-  const [apiBase, setApiBase] = useState(get('apiBase','http://localhost:8080'));
-  const [supabaseUrl, setSupabaseUrl] = useState(get('supabaseUrl',''));
-  const [supabaseAnon, setSupabaseAnon] = useState(get('supabaseAnon',''));
-
-  const [meetupApi, setMeetupApi] = useState({ token: get('m_api_token',''), group: get('m_api_group','') });
-  const [meetupUi, setMeetupUi] = useState({ email: get('m_ui_email',''), password: get('m_ui_pw',''), groupUrl: get('m_ui_groupUrl','') });
-  const [ebApi, setEbApi] = useState({ token: get('eb_api_token','') });
-  const [ebUi, setEbUi] = useState({ email: get('eb_ui_email',''), password: get('eb_ui_pw','') });
-  const [fbApi, setFbApi] = useState({ pageId: get('fb_api_pageId',''), pageToken: get('fb_api_pageToken','') });
-  const [fbUi, setFbUi] = useState({ email: get('fb_ui_email',''), password: get('fb_ui_pw','') });
-  const [spUi, setSpUi] = useState({ email: get('sp_ui_email',''), password: get('sp_ui_pw','') });
-
-  function persistConnectivity() {
-    set('appMode', mode);
-    set('apiBase', apiBase);
-    set('supabaseUrl', supabaseUrl);
-    set('supabaseAnon', supabaseAnon);
-    alert('Konnektivität gespeichert.');
-  }
-  function saveMeetupApi() { set('m_api_token', meetupApi.token); set('m_api_group', meetupApi.group); alert('Meetup API gespeichert.'); }
-  function saveMeetupUi() { set('m_ui_email', meetupUi.email); set('m_ui_pw', meetupUi.password); set('m_ui_groupUrl', meetupUi.groupUrl); alert('Meetup UI gespeichert.'); }
-  function saveEbApi() { set('eb_api_token', ebApi.token); alert('Eventbrite API gespeichert.'); }
-  function saveEbUi() { set('eb_ui_email', ebUi.email); set('eb_ui_pw', ebUi.password); alert('Eventbrite UI gespeichert.'); }
-  function saveFbApi() { set('fb_api_pageId', fbApi.pageId); set('fb_api_pageToken', fbApi.pageToken); alert('Facebook API gespeichert.'); }
-  function saveFbUi() { set('fb_ui_email', fbUi.email); set('fb_ui_pw', fbUi.password); alert('Facebook UI gespeichert.'); }
-  function saveSpUi() { set('sp_ui_email', spUi.email); set('sp_ui_pw', spUi.password); alert('Spontacts UI gespeichert.'); }
+  const [tab, setTab] = useState<'dashboard'|'platforms'|'logs'>('dashboard');
 
   return (
     <div className="min-h-screen grid grid-rows-[auto_1fr] font-sans">
@@ -49,113 +20,11 @@ export default function App() {
 
       <main className="max-w-5xl mx-auto p-4 md:p-8 space-y-8">
         {tab==='platforms' && (
-          <>
-            <section className="space-y-3">
-              <h1 className="text-2xl font-semibold">Plattformen – Konnektivität</h1>
-              <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-3">
-                <label className="text-sm">Modus
-                  <select className="w-full border rounded p-2 mt-1" value={mode} onChange={(e)=>setMode(e.target.value)}>
-                    <option value="api">Backend API</option>
-                    <option value="supabase">Supabase direkt</option>
-                  </select>
-                </label>
-                <label className="text-sm">API Server URL
-                  <input className="w-full border rounded p-2 mt-1" value={apiBase} onChange={(e)=>setApiBase(e.target.value)} placeholder="http://localhost:8080" />
-                </label>
-                <label className="text-sm">DB URL (Supabase URL)
-                  <input className="w-full border rounded p-2 mt-1" value={supabaseUrl} onChange={(e)=>setSupabaseUrl(e.target.value)} placeholder="https://xyz.supabase.co" />
-                </label>
-                <label className="text-sm">Supabase Anon Key
-                  <input className="w-full border rounded p-2 mt-1" value={supabaseAnon} onChange={(e)=>setSupabaseAnon(e.target.value)} placeholder="public anon key" />
-                </label>
-              </div>
-              <p className="text-xs text-gray-500">Wenn in Vercel ENV gesetzt sind, werden sie automatisch genutzt; die Felder hier dienen als Fallback.</p>
-              <div className="text-right"><button className="px-4 py-2 rounded bg-blue-600 text-white" onClick={persistConnectivity}>Übernehmen</button></div>
-            </section>
-
-            <section className="space-y-4">
-              <h2 className="text-xl font-semibold">Meetup</h2>
-              <div className="grid md:grid-cols-2 gap-4">
-                <div className="border rounded p-3 space-y-2">
-                  <div className="font-medium">API</div>
-                  <input className="w-full border rounded p-2" placeholder="API Token" value={meetupApi.token} onChange={(e)=>setMeetupApi({...meetupApi, token:e.target.value})} />
-                  <input className="w-full border rounded p-2" placeholder="Group Slug" value={meetupApi.group} onChange={(e)=>setMeetupApi({...meetupApi, group:e.target.value})} />
-                  <div className="text-right"><button className="px-3 py-1 rounded bg-gray-900 text-white" onClick={saveMeetupApi}>Speichern</button></div>
-                </div>
-                <div className="border rounded p-3 space-y-2">
-                  <div className="font-medium">UI-Bot</div>
-                  <input className="w-full border rounded p-2" placeholder="Login E-Mail" value={meetupUi.email} onChange={(e)=>setMeetupUi({...meetupUi, email:e.target.value})} />
-                  <input className="w-full border rounded p-2" type="password" placeholder="Login Passwort" value={meetupUi.password} onChange={(e)=>setMeetupUi({...meetupUi, password:e.target.value})} />
-                  <input className="w-full border rounded p-2" placeholder="Group URL (optional)" value={meetupUi.groupUrl} onChange={(e)=>setMeetupUi({...meetupUi, groupUrl:e.target.value})} />
-                  <div className="text-right"><button className="px-3 py-1 rounded bg-gray-900 text-white" onClick={saveMeetupUi}>Speichern</button></div>
-                </div>
-              </div>
-            </section>
-
-            <section className="space-y-4">
-              <h2 className="text-xl font-semibold">Eventbrite</h2>
-              <div className="grid md:grid-cols-2 gap-4">
-                <div className="border rounded p-3 space-y-2">
-                  <div className="font-medium">API</div>
-                  <input className="w-full border rounded p-2" placeholder="API Token" value={ebApi.token} onChange={(e)=>setEbApi({...ebApi, token:e.target.value})} />
-                  <div className="text-right"><button className="px-3 py-1 rounded bg-gray-900 text-white" onClick={saveEbApi}>Speichern</button></div>
-                </div>
-                <div className="border rounded p-3 space-y-2">
-                  <div className="font-medium">UI-Bot</div>
-                  <input className="w-full border rounded p-2" placeholder="Login E-Mail" value={ebUi.email} onChange={(e)=>setEbUi({...ebUi, email:e.target.value})} />
-                  <input className="w-full border rounded p-2" type="password" placeholder="Login Passwort" value={ebUi.password} onChange={(e)=>setEbUi({...ebUi, password:e.target.value})} />
-                  <div className="text-right"><button className="px-3 py-1 rounded bg-gray-900 text-white" onClick={saveEbUi}>Speichern</button></div>
-                </div>
-              </div>
-            </section>
-
-            <section className="space-y-4">
-              <h2 className="text-xl font-semibold">Facebook Events</h2>
-              <div className="grid md:grid-cols-2 gap-4">
-                <div className="border rounded p-3 space-y-2">
-                  <div className="font-medium">API</div>
-                  <input className="w-full border rounded p-2" placeholder="Page ID" value={fbApi.pageId} onChange={(e)=>setFbApi({...fbApi, pageId:e.target.value})} />
-                  <input className="w-full border rounded p-2" placeholder="Page Token" value={fbApi.pageToken} onChange={(e)=>setFbApi({...fbApi, pageToken:e.target.value})} />
-                  <div className="text-right"><button className="px-3 py-1 rounded bg-gray-900 text-white" onClick={saveFbApi}>Speichern</button></div>
-                </div>
-                <div className="border rounded p-3 space-y-2">
-                  <div className="font-medium">UI-Bot</div>
-                  <input className="w-full border rounded p-2" placeholder="Login E-Mail" value={fbUi.email} onChange={(e)=>setFbUi({...fbUi, email:e.target.value})} />
-                  <input className="w-full border rounded p-2" type="password" placeholder="Login Passwort" value={fbUi.password} onChange={(e)=>setFbUi({...fbUi, password:e.target.value})} />
-                  <div className="text-right"><button className="px-3 py-1 rounded bg-gray-900 text-white" onClick={saveFbUi}>Speichern</button></div>
-                </div>
-              </div>
-            </section>
-
-            <section className="space-y-4">
-              <h2 className="text-xl font-semibold">Spontacts.de</h2>
-              <div className="grid md:grid-cols-2 gap-4">
-                <div className="border rounded p-3 space-y-2 opacity-60 pointer-events-none">
-                  <div className="font-medium">API</div>
-                  <input className="w-full border rounded p-2" placeholder="Nicht verfügbar" disabled />
-                </div>
-                <div className="border rounded p-3 space-y-2">
-                  <div className="font-medium">UI-Bot</div>
-                  <input className="w-full border rounded p-2" placeholder="Login E-Mail" value={spUi.email} onChange={(e)=>setSpUi({...spUi, email:e.target.value})} />
-                  <input className="w-full border rounded p-2" type="password" placeholder="Login Passwort" value={spUi.password} onChange={(e)=>setSpUi({...spUi, password:e.target.value})} />
-                  <div className="text-right"><button className="px-3 py-1 rounded bg-gray-900 text-white" onClick={saveSpUi}>Speichern</button></div>
-                </div>
-              </div>
-            </section>
-          </>
+          <PlatformsInline />
         )}
 
         {tab==='dashboard' && (
-          <>
-            <h1 className="text-2xl font-semibold">Event-Verteiler Dashboard</h1>
-            <div className="mt-3 border rounded p-3">
-              <div className="text-sm mb-2">Events</div>
-              <div className="text-gray-500 text-sm">(Backend/Supabase-Anbindung folgt nach Konfiguration)</div>
-              <div className="mt-2 grid grid-cols-5 text-sm font-medium">
-                <div>Titel</div><div>Datum</div><div>Kategorie</div><div>Status</div><div className="text-right">Aktionen</div>
-              </div>
-            </div>
-          </>
+          <Dashboard />
         )}
 
         {tab==='logs' && (

--- a/event-distributor/src/components/EventForm.tsx
+++ b/event-distributor/src/components/EventForm.tsx
@@ -19,26 +19,39 @@ export function EventForm({ initial, onSubmit, onCancel }: { initial?: Partial<E
     images: initial?.images || [],
     organizer: initial?.organizer || '',
     url: initial?.url || '',
-  });
+    spontacts: (initial as any)?.spontacts || {}
+  } as any);
 
   return (
     <div className="space-y-3">
-      <Input placeholder="Titel" value={v.title || ''} onChange={(e) => setV({ ...v, title: e.target.value })} />
-      <Textarea placeholder="Beschreibung" value={v.description || ''} onChange={(e) => setV({ ...v, description: e.target.value })} />
+      <Input placeholder="Titel" value={(v as any).title || ''} onChange={(e) => setV({ ...v, title: e.target.value } as any)} />
+      <Textarea placeholder="Beschreibung" value={(v as any).description || ''} onChange={(e) => setV({ ...v, description: e.target.value } as any)} />
       <div className="grid grid-cols-2 gap-2">
-        <Input type="date" value={v.date?.slice(0,10) || ''} onChange={(e) => setV({ ...v, date: e.target.value ? new Date(e.target.value).toISOString() : '' })} />
-        <Input type="time" value={v.time || ''} onChange={(e) => setV({ ...v, time: e.target.value })} />
+        <Input type="date" value={(v as any).date?.slice(0,10) || ''} onChange={(e) => setV({ ...v, date: e.target.value ? new Date(e.target.value).toISOString() : '' } as any)} />
+        <Input type="time" value={(v as any).time || ''} onChange={(e) => setV({ ...v, time: e.target.value } as any)} />
       </div>
-      <Input placeholder="Ort (JSON oder Text)" value={typeof v.location === 'string' ? v.location : JSON.stringify(v.location || '')} onChange={(e) => setV({ ...v, location: e.target.value })} />
-      <Input placeholder="Kategorie" value={v.category || ''} onChange={(e) => setV({ ...v, category: e.target.value })} />
-      <Input placeholder="Tags (Komma-getrennt)" value={(v.tags || []).join(',')} onChange={(e) => setV({ ...v, tags: e.target.value.split(',').map((t) => t.trim()).filter(Boolean) })} />
-      <Input placeholder="Bilder (Komma-getrennt)" value={(v.images || []).join(',')} onChange={(e) => setV({ ...v, images: e.target.value.split(',').map((t) => t.trim()).filter(Boolean) })} />
+      <Input placeholder="Ort (JSON oder Text)" value={typeof (v as any).location === 'string' ? (v as any).location : JSON.stringify((v as any).location || '')} onChange={(e) => setV({ ...v, location: e.target.value } as any)} />
+      <Input placeholder="Kategorie" value={(v as any).category || ''} onChange={(e) => setV({ ...v, category: e.target.value } as any)} />
+      <Input placeholder="Tags (Komma-getrennt)" value={((v as any).tags || []).join(',')} onChange={(e) => setV({ ...v, tags: e.target.value.split(',').map((t) => t.trim()).filter(Boolean) } as any)} />
+      <Input placeholder="Bilder (Komma-getrennt)" value={((v as any).images || []).join(',')} onChange={(e) => setV({ ...v, images: e.target.value.split(',').map((t) => t.trim()).filter(Boolean) } as any)} />
       <div className="grid grid-cols-2 gap-2">
-        <Input placeholder="Preis" type="number" value={v.price ?? ''} onChange={(e) => setV({ ...v, price: e.target.value ? Number(e.target.value) : undefined })} />
-        <div className="flex items-center gap-2"><Switch checked={!!v.isVirtual} onCheckedChange={(c) => setV({ ...v, isVirtual: c })} /> <span>Virtuell?</span></div>
+        <Input placeholder="Preis" type="number" value={(v as any).price ?? ''} onChange={(e) => setV({ ...v, price: e.target.value ? Number(e.target.value) : undefined } as any)} />
+        <div className="flex items-center gap-2"><Switch checked={!!(v as any).isVirtual} onCheckedChange={(c) => setV({ ...v, isVirtual: c } as any)} /> <span>Virtuell?</span></div>
       </div>
-      <Input placeholder="Veranstalter" value={v.organizer || ''} onChange={(e) => setV({ ...v, organizer: e.target.value })} />
-      <Input placeholder="URL" value={v.url || ''} onChange={(e) => setV({ ...v, url: e.target.value })} />
+      <Input placeholder="Veranstalter" value={(v as any).organizer || ''} onChange={(e) => setV({ ...v, organizer: e.target.value } as any)} />
+      <Input placeholder="URL" value={(v as any).url || ''} onChange={(e) => setV({ ...v, url: e.target.value } as any)} />
+
+      <div className="pt-2">
+        <div className="text-sm font-medium">Spontacts – Details</div>
+        <div className="grid md:grid-cols-2 gap-2 mt-2">
+          <Input placeholder="Kategorie (Spontacts)" value={(v as any).spontacts?.category || ''} onChange={(e)=>setV({ ...v, spontacts: { ...(v as any).spontacts, category: e.target.value } } as any)} />
+          <Input placeholder="Stadt" value={(v as any).spontacts?.city || ''} onChange={(e)=>setV({ ...v, spontacts: { ...(v as any).spontacts, city: e.target.value } } as any)} />
+          <Input placeholder="Treffpunkt" value={(v as any).spontacts?.meetingPoint || ''} onChange={(e)=>setV({ ...v, spontacts: { ...(v as any).spontacts, meetingPoint: e.target.value } } as any)} />
+          <Input placeholder="Max. Teilnehmer" type="number" value={(v as any).spontacts?.maxParticipants ?? ''} onChange={(e)=>setV({ ...v, spontacts: { ...(v as any).spontacts, maxParticipants: e.target.value ? Number(e.target.value) : undefined } } as any)} />
+          <Input placeholder="Sichtbarkeit (public/friends/private)" value={(v as any).spontacts?.visibility || ''} onChange={(e)=>setV({ ...v, spontacts: { ...(v as any).spontacts, visibility: e.target.value as any } } as any)} />
+          <Input placeholder="Schwierigkeit (frei)" value={(v as any).spontacts?.difficulty || ''} onChange={(e)=>setV({ ...v, spontacts: { ...(v as any).spontacts, difficulty: e.target.value } } as any)} />
+        </div>
+      </div>
 
       <div className="flex justify-end gap-2 pt-2">
         {onCancel && (<Button variant="outline" onClick={onCancel}>Abbrechen</Button>)}

--- a/event-distributor/src/components/PlatformsInline.tsx
+++ b/event-distributor/src/components/PlatformsInline.tsx
@@ -3,8 +3,8 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Switch } from '@/components/ui/switch';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { api } from '@/services/api';
 import { getApiBase, setApiBase, getSupabaseUrl, setSupabaseUrl, getSupabaseAnon, setSupabaseAnon, getMode, setMode } from '@/services/config';
+import { listPlatformConfigs, savePlatformConfig } from '@/services/data';
 
 export function PlatformsInline() {
   const [items, setItems] = useState<any[]>([]);
@@ -16,10 +16,10 @@ export function PlatformsInline() {
 
   async function load() {
     try {
-      const data = await api<any[]>('/api/platforms');
+      const data = await listPlatformConfigs();
       setItems(data);
     } catch (_) {
-      // ignore until API base set
+      // ignore
     }
   }
   useEffect(() => { load(); }, []);
@@ -36,12 +36,7 @@ export function PlatformsInline() {
 
   async function save(platform: string, method: 'api'|'ui', config: any, enabled = true) {
     setLoading(true);
-    const exist = getCfg(platform, method);
-    if (exist) {
-      await api(`/api/platforms/${exist.id}`, { method: 'PUT', body: JSON.stringify({ config, enabled }) });
-    } else {
-      await api('/api/platforms', { method: 'POST', body: JSON.stringify({ platform, method, name: `${platform} ${method}`, config, enabled }) });
-    }
+    await savePlatformConfig(platform, method, config, enabled);
     setLoading(false);
     await load();
   }

--- a/event-distributor/src/components/PublishDrawer.tsx
+++ b/event-distributor/src/components/PublishDrawer.tsx
@@ -4,7 +4,9 @@ import { Button } from '@/components/ui/button';
 import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from '@/components/ui/select';
 import { Input } from '@/components/ui/input';
 import type { PlatformKey, PublishMethod } from '../../shared/types';
+import { getMode } from '@/services/config';
 import { api } from '@/services/api';
+import { schedulePublishJob } from '@/services/data';
 
 export function PublishDrawer({ open, onOpenChange, eventId }: { open: boolean; onOpenChange: (v: boolean) => void; eventId: string }) {
   const [platform, setPlatform] = useState<PlatformKey>('meetup');
@@ -15,10 +17,11 @@ export function PublishDrawer({ open, onOpenChange, eventId }: { open: boolean; 
   async function submit() {
     setLoading(true);
     try {
-      await api('/api/publish', {
-        method: 'POST',
-        body: JSON.stringify({ eventId, platform, method, action: 'create', scheduledAt: when || undefined }),
-      });
+      if (getMode() === 'api') {
+        await api('/api/publish', { method: 'POST', body: JSON.stringify({ eventId, platform, method, action: 'create', scheduledAt: when || undefined }) });
+      } else {
+        await schedulePublishJob({ eventId, platform, method, action: 'create', scheduledAt: when || undefined });
+      }
       onOpenChange(false);
     } finally { setLoading(false); }
   }

--- a/event-distributor/supabase/schema.sql
+++ b/event-distributor/supabase/schema.sql
@@ -16,9 +16,17 @@ create table if not exists "Event" (
   images text[] default '{}',
   organizer text,
   url text,
+  spontacts jsonb default '{}',
   "createdAt" timestamptz not null default now(),
   "updatedAt" timestamptz not null default now()
 );
+
+-- Ensure column exists in migrated DBs
+do $$ begin
+  if not exists (select 1 from information_schema.columns where table_name='Event' and column_name='spontacts') then
+    alter table "Event" add column spontacts jsonb default '{}';
+  end if;
+end $$;
 
 create table if not exists "EventVersion" (
   id uuid primary key default gen_random_uuid(),


### PR DESCRIPTION
Implements Spontacts publishing pipeline with Supabase-only frontend.

Changes
- Event schema: add spontacts jsonb for platform-specific fields (safe, default '{}').
- EventForm: inputs for Spontacts (category, city, meetingPoint, maxParticipants, visibility, difficulty).
- Dashboard: real event CRUD UI integrated.
- PublishDrawer: if mode=supabase, creates PublishJob row (scheduled) instead of hitting backend API.
- PlatformsInline: read/write PlatformConfig via Supabase (no backend).
- Bots: Spontacts UI bot maps Event→Spontacts fields via shared mapping.

How it works
- Create event in Dashboard (fill Spontacts section as needed).
- Ensure Spontacts UI credentials saved under Plattformen (now stored in Supabase PlatformConfig).
- Publish (UI-Bot + Spontacts); a PublishJob row is created. The bots runner can poll and execute.

Note
- Actual execution of Playwright bots is out of the frontend scope; use bots/runner with Supabase to fetch jobs and run.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Scout](https://scout.new) ([view task](https://scout.new/project/24cf7f97-98af-44eb-906e-389df10ea0d4/task/d4630fbf-f03a-42a4-b077-7193e244591d))