### PR TITLE
Load platform field options dynamically; Spontacts categories/visibility/difficulty via Playwright + Supabase cache

### DIFF
--- a/event-distributor/bots/src/shared/helpers.ts
+++ b/event-distributor/bots/src/shared/helpers.ts
@@ -19,6 +19,52 @@ export async function smartFill(page: Page, label: string, value: string) {
   return false;
 }
 
+export async function smartSelect(page: Page, label: string, value: string) {
+  const selectCandidates = [
+    page.getByLabel(label),
+    page.getByRole('combobox', { name: label }),
+    page.getByText(label).locator('..').locator('select'),
+    page.locator(`label:has-text("${label}")`).locator('..').locator('select'),
+  ];
+  for (const c of selectCandidates) {
+    const count = await c.count().catch(() => 0);
+    if (count) {
+      const el = c.first();
+      try {
+        await el.selectOption({ label: value });
+        return true;
+      } catch {}
+      try {
+        await el.selectOption(value);
+        return true;
+      } catch {}
+      try {
+        await el.fill(value);
+        return true;
+      } catch {}
+    }
+  }
+  // Try opening a dropdown and clicking by option text
+  const triggers = [
+    page.getByLabel(label),
+    page.getByRole('combobox', { name: label }),
+    page.getByText(label).locator('..').locator('input,[role="combobox"],button'),
+  ];
+  for (const t of triggers) {
+    if (await t.count().catch(() => 0)) {
+      try {
+        await t.first().click({ force: true });
+        const opt = page.getByRole('option', { name: value }).first();
+        if (await opt.count().catch(() => 0)) {
+          await opt.click({ force: true });
+          return true;
+        }
+      } catch {}
+    }
+  }
+  return false;
+}
+
 export async function clickByText(page: Page, text: string) {
   const candidates = [page.getByRole('button', { name: text }), page.getByText(text, { exact: true })];
   for (const c of candidates) {

--- a/event-distributor/bots/src/spontacts/createEvent.ts
+++ b/event-distributor/bots/src/spontacts/createEvent.ts
@@ -1,6 +1,6 @@
 import { chromium } from '@playwright/test';
 import { loadOrCreateSession } from '../shared/session.js';
-import { smartFill, clickByText } from '../shared/helpers.js';
+import { smartFill, smartSelect, clickByText } from '../shared/helpers.js';
 import { createArtifacts } from '../shared/logging.js';
 import { mapToSpontactsFields } from '../../../shared/platforms/spontacts';
 
@@ -40,11 +40,13 @@ const cfg = JSON.parse(process.env.BOT_CONFIG || '{}');
     if (m.description) await smartFill(page, 'Beschreibung', m.description) || await smartFill(page, 'Description', m.description);
     if (m.date) await smartFill(page, 'Datum', new Date(m.date).toLocaleDateString()) || await smartFill(page, 'Date', new Date(m.date).toLocaleDateString());
     if (m.time) await smartFill(page, 'Uhrzeit', m.time) || await smartFill(page, 'Time', m.time);
-    if (m.category) await smartFill(page, 'Kategorie', m.category) || await smartFill(page, 'Category', m.category);
+    if (m.category) (await smartSelect(page, 'Kategorie', m.category)) || (await smartSelect(page, 'Category', m.category)) || (await smartFill(page, 'Kategorie', m.category)) || (await smartFill(page, 'Category', m.category));
     if (m.city) await smartFill(page, 'Ort', m.city) || await smartFill(page, 'City', m.city);
     if (m.meetingPoint) await smartFill(page, 'Treffpunkt', m.meetingPoint) || await smartFill(page, 'Meeting point', m.meetingPoint);
     if (m.maxParticipants) await smartFill(page, 'Teilnehmer', String(m.maxParticipants)) || await smartFill(page, 'Participants', String(m.maxParticipants));
     if (m.price) await smartFill(page, 'Preis', String(m.price)) || await smartFill(page, 'Price', String(m.price));
+    if (m.visibility) (await smartSelect(page, 'Sichtbarkeit', m.visibility)) || (await smartSelect(page, 'Visibility', m.visibility));
+    if (m.difficulty) (await smartSelect(page, 'Schwierigkeit', m.difficulty)) || (await smartSelect(page, 'Difficulty', m.difficulty));
 
     await clickByText(page, 'Veröffentlichen') || await clickByText(page, 'Publish');
     await page.waitForLoadState('networkidle');

--- a/event-distributor/bots/src/spontacts/discoverOptions.ts
+++ b/event-distributor/bots/src/spontacts/discoverOptions.ts
@@ -1,0 +1,78 @@
+import { chromium } from '@playwright/test';
+import { loadOrCreateSession } from '../shared/session.js';
+import { clickByText } from '../shared/helpers.js';
+
+const jobId = process.env.JOB_ID || 'local';
+const cfg = JSON.parse(process.env.BOT_CONFIG || '{}');
+
+(async () => {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext();
+  const session = await loadOrCreateSession(context, 'spontacts');
+  const page = await context.newPage();
+  try {
+    await page.goto('https://www.spontacts.com/');
+    await page.waitForLoadState('domcontentloaded');
+
+    if (cfg.email && cfg.password) {
+      await clickByText(page, 'Login').catch(() => {});
+      await page.waitForLoadState('networkidle').catch(() => {});
+      try {
+        await page.getByLabel('E-Mail').fill(cfg.email);
+      } catch { try { await page.getByLabel('Email').fill(cfg.email); } catch {}
+      }
+      try {
+        await page.getByLabel('Passwort').fill(cfg.password);
+      } catch { try { await page.getByLabel('Password').fill(cfg.password); } catch {}
+      }
+      await clickByText(page, 'Anmelden').catch(() => clickByText(page, 'Login'));
+      await page.waitForLoadState('networkidle');
+      await session.save();
+    }
+
+    const createBtn = (await clickByText(page, 'Aktivität erstellen')) || (await clickByText(page, 'Create activity'));
+    if (!createBtn) {
+      await page.goto('https://www.spontacts.com/activities/new').catch(() => {});
+    }
+    await page.waitForLoadState('domcontentloaded');
+
+    const entries = await page.evaluate(() => {
+      const out: { label: string; options: string[] }[] = [];
+      const uniq = (arr: string[]) => Array.from(new Set(arr.map((s) => s.trim()).filter(Boolean)));
+      // Map labels to associated select element via 'for' attribute or proximity
+      const labels = Array.from(document.querySelectorAll('label')) as HTMLLabelElement[];
+      for (const label of labels) {
+        const text = (label.textContent || '').trim();
+        let el: HTMLElement | null = null;
+        const id = label.getAttribute('for');
+        if (id) el = document.getElementById(id);
+        if (!el) {
+          const next = label.nextElementSibling as HTMLElement | null;
+          if (next && next.tagName === 'SELECT') el = next;
+          if (!el) {
+            const parentSelect = label.parentElement?.querySelector('select') as HTMLElement | null;
+            if (parentSelect) el = parentSelect;
+          }
+        }
+        if (el && el.tagName === 'SELECT') {
+          const select = el as HTMLSelectElement;
+          const opts = uniq(Array.from(select.options).map((o) => o.textContent || ''));
+          if (opts.length) out.push({ label: text, options: opts });
+        }
+      }
+      return out;
+    });
+
+    const map: Record<string, string[]> = {};
+    const pick = (matcher: RegExp) => entries.find((e) => matcher.test(e.label))?.options || [];
+    map['category'] = pick(/kategor|categ/i);
+    map['visibility'] = pick(/sichtbar|visib/i);
+    map['difficulty'] = pick(/schwier|diffic/i);
+
+    console.log(JSON.stringify({ ok: true, options: map }));
+    await browser.close();
+  } catch (e) {
+    await browser.close();
+    throw e;
+  }
+})();

--- a/event-distributor/src/components/EventForm.tsx
+++ b/event-distributor/src/components/EventForm.tsx
@@ -1,9 +1,11 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import type { EventInput } from '../../shared/types';
+import { listFieldOptionsFor } from '@/services/data';
 
 export function EventForm({ initial, onSubmit, onCancel }: { initial?: Partial<EventInput>; onSubmit: (v: EventInput) => void; onCancel?: () => void }) {
   const [v, setV] = useState<EventInput>({
@@ -21,6 +23,22 @@ export function EventForm({ initial, onSubmit, onCancel }: { initial?: Partial<E
     url: initial?.url || '',
     spontacts: (initial as any)?.spontacts || {}
   } as any);
+
+  const [spOpts, setSpOpts] = useState<Record<string, string[]>>({});
+  useEffect(() => {
+    (async () => {
+      try {
+        const opts = await listFieldOptionsFor('spontacts', 'ui');
+        setSpOpts(opts || {});
+      } catch {
+        setSpOpts({});
+      }
+    })();
+  }, []);
+
+  const catOptions = spOpts['category'] || [];
+  const visOptions = spOpts['visibility'] || [];
+  const difOptions = spOpts['difficulty'] || [];
 
   return (
     <div className="space-y-3">
@@ -44,12 +62,51 @@ export function EventForm({ initial, onSubmit, onCancel }: { initial?: Partial<E
       <div className="pt-2">
         <div className="text-sm font-medium">Spontacts – Details</div>
         <div className="grid md:grid-cols-2 gap-2 mt-2">
-          <Input placeholder="Kategorie (Spontacts)" value={(v as any).spontacts?.category || ''} onChange={(e)=>setV({ ...v, spontacts: { ...(v as any).spontacts, category: e.target.value } } as any)} />
+          {catOptions.length > 0 ? (
+            <div>
+              <div className="text-xs text-muted-foreground mb-1">Kategorie (Spontacts)</div>
+              <Select value={(v as any).spontacts?.category || ''} onValueChange={(val)=>setV({ ...v, spontacts: { ...(v as any).spontacts, category: val } } as any)}>
+                <SelectTrigger className="w-full"><SelectValue placeholder="Kategorie wählen" /></SelectTrigger>
+                <SelectContent>
+                  {catOptions.map((o)=> (<SelectItem key={o} value={o}>{o}</SelectItem>))}
+                </SelectContent>
+              </Select>
+            </div>
+          ) : (
+            <Input placeholder="Kategorie (Spontacts)" value={(v as any).spontacts?.category || ''} onChange={(e)=>setV({ ...v, spontacts: { ...(v as any).spontacts, category: e.target.value } } as any)} />
+          )}
+
           <Input placeholder="Stadt" value={(v as any).spontacts?.city || ''} onChange={(e)=>setV({ ...v, spontacts: { ...(v as any).spontacts, city: e.target.value } } as any)} />
           <Input placeholder="Treffpunkt" value={(v as any).spontacts?.meetingPoint || ''} onChange={(e)=>setV({ ...v, spontacts: { ...(v as any).spontacts, meetingPoint: e.target.value } } as any)} />
           <Input placeholder="Max. Teilnehmer" type="number" value={(v as any).spontacts?.maxParticipants ?? ''} onChange={(e)=>setV({ ...v, spontacts: { ...(v as any).spontacts, maxParticipants: e.target.value ? Number(e.target.value) : undefined } } as any)} />
-          <Input placeholder="Sichtbarkeit (public/friends/private)" value={(v as any).spontacts?.visibility || ''} onChange={(e)=>setV({ ...v, spontacts: { ...(v as any).spontacts, visibility: e.target.value as any } } as any)} />
-          <Input placeholder="Schwierigkeit (frei)" value={(v as any).spontacts?.difficulty || ''} onChange={(e)=>setV({ ...v, spontacts: { ...(v as any).spontacts, difficulty: e.target.value } } as any)} />
+
+          {visOptions.length > 0 ? (
+            <div>
+              <div className="text-xs text-muted-foreground mb-1">Sichtbarkeit</div>
+              <Select value={(v as any).spontacts?.visibility || ''} onValueChange={(val)=>setV({ ...v, spontacts: { ...(v as any).spontacts, visibility: val as any } } as any)}>
+                <SelectTrigger className="w-full"><SelectValue placeholder="Sichtbarkeit wählen" /></SelectTrigger>
+                <SelectContent>
+                  {visOptions.map((o)=> (<SelectItem key={o} value={o}>{o}</SelectItem>))}
+                </SelectContent>
+              </Select>
+            </div>
+          ) : (
+            <Input placeholder="Sichtbarkeit (public/friends/private)" value={(v as any).spontacts?.visibility || ''} onChange={(e)=>setV({ ...v, spontacts: { ...(v as any).spontacts, visibility: e.target.value as any } } as any)} />
+          )}
+
+          {difOptions.length > 0 ? (
+            <div>
+              <div className="text-xs text-muted-foreground mb-1">Schwierigkeit</div>
+              <Select value={(v as any).spontacts?.difficulty || ''} onValueChange={(val)=>setV({ ...v, spontacts: { ...(v as any).spontacts, difficulty: val } } as any)}>
+                <SelectTrigger className="w-full"><SelectValue placeholder="Schwierigkeit wählen" /></SelectTrigger>
+                <SelectContent>
+                  {difOptions.map((o)=> (<SelectItem key={o} value={o}>{o}</SelectItem>))}
+                </SelectContent>
+              </Select>
+            </div>
+          ) : (
+            <Input placeholder="Schwierigkeit (frei)" value={(v as any).spontacts?.difficulty || ''} onChange={(e)=>setV({ ...v, spontacts: { ...(v as any).spontacts, difficulty: e.target.value } } as any)} />
+          )}
         </div>
       </div>
 

--- a/event-distributor/src/components/PlatformsInline.tsx
+++ b/event-distributor/src/components/PlatformsInline.tsx
@@ -4,7 +4,7 @@ import { Switch } from '@/components/ui/switch';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { getApiBase, setApiBase, getSupabaseUrl, setSupabaseUrl, getSupabaseAnon, setSupabaseAnon, getMode, setMode } from '@/services/config';
-import { listPlatformConfigs, savePlatformConfig } from '@/services/data';
+import { listPlatformConfigs, savePlatformConfig, scheduleOptionDiscovery } from '@/services/data';
 
 export function PlatformsInline() {
   const [items, setItems] = useState<any[]>([]);
@@ -164,7 +164,10 @@ export function PlatformsInline() {
               <div className="flex items-center justify-between"><div className="font-medium">UI-Bot</div><Switch checked={enabled('spontacts','ui')} onCheckedChange={(c)=>save('spontacts','ui', spUi, c)} /></div>
               <Input placeholder="Login E-Mail" value={spUi.email} onChange={(e)=>setSpUi({...spUi, email:e.target.value})} />
               <Input placeholder="Login Passwort" type="password" value={spUi.password} onChange={(e)=>setSpUi({...spUi, password:e.target.value})} />
-              <div className="text-right"><Button size="sm" disabled={loading} onClick={()=>save('spontacts','ui', spUi, true)}>{loading?'Speichern…':'Speichern'}</Button></div>
+              <div className="flex items-center justify-between gap-2">
+                <Button size="sm" variant="outline" disabled={loading} onClick={()=>scheduleOptionDiscovery('spontacts','ui')}>Feld-Optionen aktualisieren</Button>
+                <div className="text-right"><Button size="sm" disabled={loading} onClick={()=>save('spontacts','ui', spUi, true)}>{loading?'Speichern…':'Speichern'}</Button></div>
+              </div>
             </div>
           </div>
         </CardContent>

--- a/event-distributor/supabase/rls_prod.sql
+++ b/event-distributor/supabase/rls_prod.sql
@@ -8,7 +8,7 @@
 --    then DROP the generic authenticated-only policies or run this in a clean project.
 --
 -- Tables covered:
---   "Event", "EventVersion", "PlatformConfig", "PublishJob", "EventPublication", "LogEntry"
+--   "Event", "EventVersion", "PlatformConfig", "PublishJob", "EventPublication", "LogEntry", "FieldOption"
 --
 -- Remove any demo/open policies before applying this file.
 
@@ -19,6 +19,7 @@ alter table "PlatformConfig" enable row level security;
 alter table "PublishJob" enable row level security;
 alter table "EventPublication" enable row level security;
 alter table "LogEntry" enable row level security;
+alter table "FieldOption" enable row level security;
 
 -- ==============================================
 -- VARIANT A (DEFAULT): Authenticated-only access
@@ -58,6 +59,12 @@ drop policy if exists "logentry_select_authenticated" on "LogEntry";
 drop policy if exists "logentry_modify_authenticated" on "LogEntry";
 create policy "logentry_select_authenticated" on "LogEntry" for select using (auth.role() = 'authenticated');
 create policy "logentry_modify_authenticated" on "LogEntry" for all using (auth.role() = 'authenticated') with check (auth.role() = 'authenticated');
+
+-- FieldOption
+drop policy if exists "fieldoption_select_authenticated" on "FieldOption";
+drop policy if exists "fieldoption_modify_authenticated" on "FieldOption";
+create policy "fieldoption_select_authenticated" on "FieldOption" for select using (auth.role() = 'authenticated');
+create policy "fieldoption_modify_authenticated" on "FieldOption" for all using (auth.role() = 'authenticated') with check (auth.role() = 'authenticated');
 
 -- =====================================================================================
 -- VARIANT B (OPTIONAL): Single admin by email (uncomment and set <ADMIN_EMAIL> to enforce)

--- a/event-distributor/supabase/schema.sql
+++ b/event-distributor/supabase/schema.sql
@@ -51,7 +51,7 @@ create table if not exists "PublishJob" (
   "eventId" uuid not null references "Event"(id) on delete cascade,
   platform text not null,
   method text not null check (method in ('api','ui')),
-  action text not null check (action in ('create','update','delete')),
+  action text not null check (action in ('create','update','delete','discover')),
   "scheduledAt" timestamptz not null,
   status text not null default 'scheduled',
   "tryCount" int not null default 0,
@@ -85,6 +85,18 @@ create table if not exists "LogEntry" (
   "createdAt" timestamptz not null default now()
 );
 
+-- Cache of field options per platform/field/method
+create table if not exists "FieldOption" (
+  id uuid primary key default gen_random_uuid(),
+  platform text not null,
+  method text, -- 'api' | 'ui' optional
+  field text not null,
+  options jsonb not null default '[]',
+  "createdAt" timestamptz not null default now(),
+  "updatedAt" timestamptz not null default now(),
+  unique (platform, method, field)
+);
+
 -- updatedAt trigger
 create or replace function set_updated_at() returns trigger as $$
 begin
@@ -97,3 +109,4 @@ create trigger trg_event_updated before update on "Event" for each row execute p
 create trigger trg_platform_updated before update on "PlatformConfig" for each row execute procedure set_updated_at();
 create trigger trg_job_updated before update on "PublishJob" for each row execute procedure set_updated_at();
 create trigger trg_pub_updated before update on "EventPublication" for each row execute procedure set_updated_at();
+create trigger trg_fieldopt_updated before update on "FieldOption" for each row execute procedure set_updated_at();


### PR DESCRIPTION
Summary\n- Add Supabase table FieldOption with RLS policies and extend PublishJob action to include 'discover'\n- Implement Playwright option discovery for Spontacts (categories/visibility/difficulty) and save to FieldOption via supabase-runner\n- Update EventForm: use Selects for Spontacts fields, loading options from FieldOption (fallback to Input if not loaded)\n- Add button in Platforms settings to refresh Spontacts field options via discovery job\n- Enhance Playwright helpers with smartSelect and update Spontacts createEvent to prefer selecting dropdowns\n\nImpact\n- Prevents invalid free-text input for platform-constrained fields\n- Ensures Playwright fills exact, platform-accepted values\n- Lays groundwork to add discovery for other platforms (API/UI) similarly\n\nWhy\n- Spontacts and similar platforms require exact predefined values for categories/visibility; free text caused rejections. This implements first-class, dynamic options.\n

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Scout](https://scout.new) ([view task](https://scout.new/project/6483f65a-fb13-4399-8fff-4758a8b0f773/task/0271c24c-dd6e-47af-872b-80cff06f7f71))