### PR TITLE
API auth: forward Supabase JWT to Vercel API (no service role)

### DIFF
--- a/event-distributor/src/services/api.ts
+++ b/event-distributor/src/services/api.ts
@@ -11,11 +11,19 @@ export function setApiBase(url: string) {
   if (typeof window !== 'undefined') localStorage.setItem('apiBase', url);
 }
 
+import { supa } from './supabase';
+
 export async function api<T>(path: string, init?: RequestInit): Promise<T> {
   const base = getApiBase();
+  let authHeader: Record<string,string> = {};
+  try {
+    const { data } = await supa().auth.getSession();
+    const token = data.session?.access_token;
+    if (token) authHeader = { Authorization: `Bearer ${token}` };
+  } catch {}
   const res = await fetch(`${base}${path}`, {
     ...init,
-    headers: { 'Content-Type': 'application/json', ...(init?.headers || {}) },
+    headers: { 'Content-Type': 'application/json', ...authHeader, ...(init?.headers || {}) },
   });
   if (!res.ok) throw new Error(await res.text());
   return res.json();


### PR DESCRIPTION
- Client forwards Supabase session JWT to /api/* so Vercel functions can read/write with RLS using anon key + Authorization.\n- Removes need for Service Role on Vercel for field-options and future endpoints.\n\nImpact\n- Tighter security (no service role in Vercel env).\n- Keeps stack: GitHub + Supabase + Vercel.\n

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Scout](https://scout.new) ([view task](https://scout.new/project/6483f65a-fb13-4399-8fff-4758a8b0f773/task/0271c24c-dd6e-47af-872b-80cff06f7f71))